### PR TITLE
Edit of README.md for clarity-dragon name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Targaryen
 
-A distributed computing framework, written in python. This is in no way
+A distributed computing framework, written in Python. This is in no way
 "perfect" and is a work in progress. The name draws inspiration from the
-Targaryen Sigil, a three headed dragon. This is the result of watching too much
+Targaryen sigil, a three headed dragon. This is the result of watching too much
 Game of Thrones. Inspiration for the actual project was taken from
 [bashmu](https://github.com/renmusxd/bashmu)
 


### PR DESCRIPTION
s/Sigil/sigil/ in line 5.

Edit for clarity. It looked as though "Sigil" was a proper noun and could have been the name of a dragon because it was capitalized. The edit makes it explicitly clear that it's a house sigil and not a dragon named Sigil.